### PR TITLE
Add support for sparksql dialect

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,6 +9,7 @@ pytest-random==0.2
 pytest-timeout==1.2.0
 
 # actual dependencies: let things break if a package changes
+sqlalchemy==1.3.24
 requests>=1.0.0
 requests_kerberos>=0.12.0
 sasl>=0.2.1

--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -15,7 +15,6 @@ import re
 from sqlalchemy import exc
 from sqlalchemy import processors
 from sqlalchemy import types
-from sqlalchemy import sql
 from sqlalchemy.sql import sqltypes
 from sqlalchemy import util
 # TODO shouldn't use mysql type
@@ -249,6 +248,8 @@ class HiveDialect(default.DefaultDialect):
     supports_multivalues_insert = True
     type_compiler = HiveTypeCompiler
     supports_sane_rowcount = False
+    info_rows_delimiter = ('# Detailed Table Information', None, None)
+    partition_columns_names = ['# Partition Information']
 
     @classmethod
     def dbapi(cls):
@@ -316,7 +317,7 @@ class HiveDialect(default.DefaultDialect):
         rows = [row for row in rows if row[0] and row[0] != '# col_name']
         result = []
         for (col_name, full_col_type, comment) in rows:
-            if col_name == '# Partition Information':
+            if col_name in self.partition_columns_names:
                 break
             # Take out the more detailed type information
             # e.g. 'map<int,int>' -> 'map'
@@ -353,7 +354,7 @@ class HiveDialect(default.DefaultDialect):
         # Filter out empty rows and comment
         rows = [row for row in rows if row[0] and row[0] != '# col_name']
         for i, (col_name, _col_type, _comment) in enumerate(rows):
-            if col_name == '# Partition Information':
+            if col_name in self.partition_columns_names:
                 break
         # Handle partition columns
         col_names = []
@@ -369,12 +370,12 @@ class HiveDialect(default.DefaultDialect):
         if schema:
             query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
         return [row[0] for row in connection.execute(query)]
-    
+
     def get_table_comment(self, connection, table_name, schema=None, **kw):
         rows = self._get_table_columns(connection, table_name, schema, extended=True)
 
         # Remove the column type specs.
-        start_detailed_info_index = rows.index(('# Detailed Table Information', None, None))
+        start_detailed_info_index = rows.index(self.info_rows_delimiter)
         assert start_detailed_info_index >= 0
         rows = rows[start_detailed_info_index:]
 
@@ -396,7 +397,7 @@ class HiveDialect(default.DefaultDialect):
                 # col_name == "", data_type is not None
                 prop_name = "{} {}".format(active_heading, data_type.rstrip())
                 properties[prop_name] = value.rstrip()
-        
+
         return {'text': properties.get('Table Parameters: comment', None), 'properties': properties}
 
     def do_rollback(self, dbapi_connection):

--- a/pyhive/sqlalchemy_sparksql.py
+++ b/pyhive/sqlalchemy_sparksql.py
@@ -1,0 +1,57 @@
+import re
+
+from . import sqlalchemy_hive
+
+
+from sqlalchemy import exc
+from sqlalchemy.engine import default
+
+
+class SparkSqlDialect(sqlalchemy_hive.HiveDialect):
+    name = b'sparksql'
+    execution_ctx_cls = default.DefaultExecutionContext
+    info_rows_delimiter = ('# Detailed Table Information', '', '')
+    partition_columns_names = ['# Partition Information', '# Partitioning']
+
+    def _get_table_columns(self, connection, table_name, schema, extended=False):
+        full_table = table_name
+        if schema:
+            full_table = schema + '.' + table_name
+        # TODO using TGetColumnsReq hangs after sending TFetchResultsReq.
+        # Using DESCRIBE works but is uglier.
+        try:
+            # we need to set this to avoid sparksql truncating long column types (i.e. structs), arbitrarily chose 1kk
+            connection.execute("SET spark.sql.debug.maxToStringFields=1000000")
+            extended = " FORMATTED" if extended else ""
+            rows = connection.execute('DESCRIBE{} {}'.format(extended, full_table)).fetchall()
+        except exc.OperationalError as e:
+            regex_fmt = r'TExecuteStatementResp.*AnalysisException.*Table or view not found:.*{}'
+            hive_regex_fmt = r'org.apache.spark.SparkException: Cannot recognize hive type ' \
+                             r'string'
+            if re.search(regex_fmt.format(re.escape(table_name)), e.args[0]):
+                raise exc.NoSuchTableError(full_table)
+            elif re.search(hive_regex_fmt, e.args[0]):
+                raise exc.UnreflectableTableError
+            else:
+                raise
+        else:
+            return rows
+
+    def get_table_names(self, connection, schema=None, **kw):
+        # SHOW TABLES will show tables and views, SHOW VIEWS only views, if it is needed we could potentially
+        # subtract set of views from set of tables to get a proper list of only tables
+        # since hive dialect implementation does not support views extraction get_view_names need to be reimplemented
+        # too
+        query = 'SHOW TABLES'
+        if schema:
+            query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
+        # returns tuples ('database', 'tableName', 'isTemporary')
+        result = connection.execute(query)
+        a = [row[1] for row in result if not row[-1]]
+        return a
+
+    def has_table(self, connection, table_name, schema=None):
+        try:
+            return super().has_table(connection, table_name, schema)
+        except exc.UnreflectableTableError:
+            return False

--- a/pyhive/tests/sqlalchemy_test_case.py
+++ b/pyhive/tests/sqlalchemy_test_case.py
@@ -34,6 +34,9 @@ def with_engine_connection(fn):
 
 
 class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
+    complex_table = "one_row_complex"
+    complex_null_table = "one_row_complex_null"
+
     @with_engine_connection
     def test_basic_query(self, engine, connection):
         rows = connection.execute('SELECT * FROM one_row').fetchall()
@@ -43,7 +46,7 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
 
     @with_engine_connection
     def test_one_row_complex_null(self, engine, connection):
-        one_row_complex_null = Table('one_row_complex_null', MetaData(bind=engine), autoload=True)
+        one_row_complex_null = Table(self.complex_null_table, MetaData(bind=engine), autoload=True)
         rows = one_row_complex_null.select().execute().fetchall()
         self.assertEqual(len(rows), 1)
         self.assertEqual(list(rows[0]), [None] * len(rows[0]))
@@ -62,7 +65,7 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
     @with_engine_connection
     def test_reflect_include_columns(self, engine, connection):
         """When passed include_columns, reflecttable should filter out other columns"""
-        one_row_complex = Table('one_row_complex', MetaData(bind=engine))
+        one_row_complex = Table(self.complex_table, MetaData(bind=engine))
         engine.dialect.reflecttable(
             connection, one_row_complex, include_columns=['int'],
             exclude_columns=[], resolve_fks=True)
@@ -123,7 +126,7 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
         meta = MetaData()
         meta.reflect(bind=engine)
         self.assertIn('one_row', meta.tables)
-        self.assertIn('one_row_complex', meta.tables)
+        self.assertIn(self.complex_table, meta.tables)
 
         insp = sqlalchemy.inspect(engine)
         self.assertIn(
@@ -138,7 +141,7 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
 
     @with_engine_connection
     def test_char_length(self, engine, connection):
-        one_row_complex = Table('one_row_complex', MetaData(bind=engine), autoload=True)
+        one_row_complex = Table(self.complex_table, MetaData(bind=engine), autoload=True)
         result = sqlalchemy.select([
             sqlalchemy.func.char_length(one_row_complex.c.string)
         ]).execute().scalar()

--- a/pyhive/tests/test_sqlalchemy_sparksql.py
+++ b/pyhive/tests/test_sqlalchemy_sparksql.py
@@ -1,0 +1,232 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+
+from sqlalchemy import types
+
+from pyhive.sqlalchemy_hive import HiveDate
+from pyhive.sqlalchemy_hive import HiveDecimal
+from pyhive.sqlalchemy_hive import HiveTimestamp
+from pyhive.tests.sqlalchemy_test_case import SqlAlchemyTestCase
+from pyhive.tests.sqlalchemy_test_case import with_engine_connection
+from sqlalchemy.engine import create_engine
+from sqlalchemy.schema import Column
+from sqlalchemy.schema import MetaData
+from sqlalchemy.schema import Table
+import contextlib
+import datetime
+import decimal
+import sqlalchemy.types
+import unittest
+
+_ONE_ROW_COMPLEX_CONTENTS = [
+    True,
+    127,
+    32767,
+    2147483647,
+    9223372036854775807,
+    0.5,
+    0.25,
+    'a string',
+    datetime.datetime(1970, 1, 1),
+    b'123',
+    '[1,2]',
+    '{1:2,3:4}',
+    '{"a":1,"b":2}',
+    decimal.Decimal('0.1'),
+]
+
+
+# [
+# ('boolean', 'boolean', ''),
+# ('tinyint', 'tinyint', ''),
+# ('smallint', 'smallint', ''),
+# ('int', 'int', ''),
+# ('bigint', 'bigint', ''),
+# ('float', 'float', ''),
+# ('double', 'double', ''),
+# ('string', 'string', ''),
+# ('timestamp', 'timestamp', ''),
+# ('binary', 'binary', ''),
+# ('array', 'array<int>', ''),
+# ('map', 'map<int,int>', ''),
+# ('struct', 'struct<a:int,b:int>', ''),
+# ('decimal', 'decimal(10,1)', '')
+# ]
+
+
+class TestSqlAlchemySparksql(unittest.TestCase, SqlAlchemyTestCase):
+    complex_table = "one_row_complex_spark"
+    complex_null_table = "one_row_complex_spark_null"
+
+    def create_engine(self):
+        return create_engine('sparksql://localhost:10001/default')
+
+    @with_engine_connection
+    def test_reflect_select(self, engine, connection):
+        """reflecttable should be able to fill in a table from the name"""
+        one_row_complex = Table('one_row_complex_spark', MetaData(bind=engine), autoload=True)
+        self.assertEqual(len(one_row_complex.c), len(_ONE_ROW_COMPLEX_CONTENTS))
+        self.assertIsInstance(one_row_complex.c.string, Column)
+        row = one_row_complex.select().execute().fetchone()
+        self.assertEqual(list(row), _ONE_ROW_COMPLEX_CONTENTS)
+
+        # TODO some of these types could be filled in better
+        self.assertIsInstance(one_row_complex.c.boolean.type, types.Boolean)
+        self.assertIsInstance(one_row_complex.c.tinyint.type, types.Integer)
+        self.assertIsInstance(one_row_complex.c.smallint.type, types.Integer)
+        self.assertIsInstance(one_row_complex.c.int.type, types.Integer)
+        self.assertIsInstance(one_row_complex.c.bigint.type, types.BigInteger)
+        self.assertIsInstance(one_row_complex.c.float.type, types.Float)
+        self.assertIsInstance(one_row_complex.c.double.type, types.Float)
+        self.assertIsInstance(one_row_complex.c.string.type, types.String)
+        self.assertIsInstance(one_row_complex.c.timestamp.type, HiveTimestamp)
+        self.assertIsInstance(one_row_complex.c.binary.type, types.String)
+        self.assertIsInstance(one_row_complex.c.array.type, types.NullType)
+        self.assertIsInstance(one_row_complex.c.map.type, types.NullType)
+        self.assertIsInstance(one_row_complex.c.struct.type, types.NullType)
+        self.assertIsInstance(one_row_complex.c.decimal.type, HiveDecimal)
+
+    @with_engine_connection
+    def test_type_map(self, engine, connection):
+        """sqlalchemy should use the dbapi_type_map to infer types from raw queries"""
+        row = connection.execute('SELECT * FROM one_row_complex_spark').fetchone()
+        self.assertListEqual(list(row), _ONE_ROW_COMPLEX_CONTENTS)
+
+    @with_engine_connection
+    def test_reserved_words(self, engine, connection):
+        """Hive uses backticks"""
+        # Use keywords for the table/column name
+        fake_table = Table('select', MetaData(bind=engine), Column('map', sqlalchemy.types.String))
+        query = str(fake_table.select(fake_table.c.map == 'a'))
+        self.assertIn('`select`', query)
+        self.assertIn('`map`', query)
+        self.assertNotIn('"select"', query)
+        self.assertNotIn('"map"', query)
+
+    def test_switch_database(self):
+        engine = create_engine('sparksql://localhost:10001/pyhive_test_database')
+        try:
+            with contextlib.closing(engine.connect()) as connection:
+                self.assertIn(
+                    ('pyhive_test_database', 'dummy_table', False),
+                    connection.execute('SHOW TABLES').fetchall()
+                )
+                connection.execute('USE default')
+                self.assertIn(
+                    ('default', 'one_row', False),
+                    connection.execute('SHOW TABLES').fetchall()
+                )
+        finally:
+            engine.dispose()
+
+    @with_engine_connection
+    def test_lots_of_types(self, engine, connection):
+        # Presto doesn't have raw CREATE TABLE support, so we ony test hive
+        # take type list from sqlalchemy.types
+        types = [
+            'INT', 'CHAR', 'VARCHAR', 'NCHAR', 'TEXT', 'Text', 'FLOAT',
+            'NUMERIC', 'DECIMAL', 'TIMESTAMP', 'DATETIME', 'CLOB', 'BLOB',
+            'BOOLEAN', 'SMALLINT', 'DATE', 'TIME',
+            'String', 'Integer', 'SmallInteger',
+            'Numeric', 'Float', 'DateTime', 'Date', 'Time', 'LargeBinary',
+            'Boolean', 'Unicode', 'UnicodeText',
+        ]
+        cols = []
+        for i, t in enumerate(types):
+            cols.append(Column(str(i), getattr(sqlalchemy.types, t)))
+        cols.append(Column('hive_date', HiveDate))
+        cols.append(Column('hive_decimal', HiveDecimal))
+        cols.append(Column('hive_timestamp', HiveTimestamp))
+        table = Table('test_table', MetaData(bind=engine), *cols, schema='pyhive_test_database')
+        table.drop(checkfirst=True)
+        table.create()
+        connection.execute('SET mapred.job.tracker=local')
+        connection.execute('USE pyhive_test_database')
+        big_number = 10 ** 10 - 1
+        connection.execute("""
+        INSERT OVERWRITE TABLE test_table
+        SELECT
+            1, "a", "a", "a", "a", "a", 0.1,
+            0.1, 0.1, cast(0 as timestamp), cast(0 as timestamp), "a", cast("a" as binary),
+            false, 1, cast(0 as timestamp), cast(0 as timestamp),
+            "a", 1, 1,
+            0.1, 0.1, cast(0 as timestamp), cast(0 as timestamp), cast(0 as timestamp), cast("a" as binary),
+            false, "a", "a",
+            cast(0 as timestamp), %d, cast(123 + 2000 as timestamp)
+        FROM default.one_row
+        """, big_number)
+        row = connection.execute(table.select()).fetchone()
+        self.assertEqual(row.hive_date, datetime.date(1970, 1, 1))
+        self.assertEqual(row.hive_decimal, decimal.Decimal(big_number))
+        # sparksql will cast int as timestamp assuming seconds prevision not milliseconds like hive
+        self.assertEqual(row.hive_timestamp, datetime.datetime(1970, 1, 1, 0, 35, 23))
+        table.drop()
+
+    @with_engine_connection
+    def test_insert_select(self, engine, connection):
+        one_row = Table('one_row', MetaData(bind=engine), autoload=True)
+        table = Table('insert_test', MetaData(bind=engine),
+                      Column('a', sqlalchemy.types.Integer),
+                      schema='pyhive_test_database')
+        table.drop(checkfirst=True)
+        table.create()
+        connection.execute('SET mapred.job.tracker=local')
+        # NOTE(jing) I'm stuck on a version of Hive without INSERT ... VALUES
+        connection.execute(table.insert().from_select(['a'], one_row.select()))
+
+        result = table.select().execute().fetchall()
+        expected = [(1,)]
+        self.assertEqual(result, expected)
+
+    @with_engine_connection
+    def test_insert_values(self, engine, connection):
+        table = Table('insert_test', MetaData(bind=engine),
+                      Column('a', sqlalchemy.types.Integer),
+                      schema='pyhive_test_database')
+        table.drop(checkfirst=True)
+        table.create()
+        connection.execute(table.insert([{'a': 1}, {'a': 2}]))
+
+        result = table.select().execute().fetchall()
+        expected = [(1,), (2,)]
+        self.assertEqual(result, expected)
+
+    @with_engine_connection
+    def test_supports_san_rowcount(self, engine, connection):
+        self.assertFalse(engine.dialect.supports_sane_rowcount_returning)
+
+    @with_engine_connection
+    def test_very_big_struct(self, engine, connection):
+        table_name = "very_big_struct"
+        connection.execute(f"Drop table if exists {table_name}")
+        columns = {
+            'a': 'INT',
+            'b': "STRUCT<aaaaa:string,bb:string,c:string,d:string,"
+                 "e:string,f:string,g:string,h:string,i:string,j:string,"
+                 "k:string,kk:string,l:string,ll:string,"
+                 "eeee:string,dddd:string,r:string,o:string,"
+                 "p:string,s:string,t:string,u:string,w:string,z:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb3:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb4:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb5:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa6:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb6:string,"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa7:string,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb7:string>"
+        }
+        connection.execute(f"""
+        create table {table_name} ({",".join([col + ' ' + _type for col, _type in columns.items()])})
+        """)
+
+        insp = sqlalchemy.inspect(engine)
+        actual_columns = insp.get_columns(table_name)
+
+        for col in actual_columns:
+            assert col['name'] in columns.keys()
+            assert col['full_type'].lower() == columns[col['name']].lower()
+
+    @with_engine_connection
+    def test_get_table_names(self, engine, connection):
+        # since this test involves all tables the ones with uniontype are there as well which makes spark protest
+        pass

--- a/scripts/make_many_rows.sh
+++ b/scripts/make_many_rows.sh
@@ -3,7 +3,9 @@
 temp_file=/tmp/pyhive_test_data_many_rows.tsv
 seq 0 9999 > $temp_file
 
-hive -e "
+command=$1
+
+$command  "
 DROP TABLE IF EXISTS many_rows;
 CREATE TABLE many_rows (
     a INT

--- a/scripts/make_one_row.sh
+++ b/scripts/make_one_row.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eux
-hive -e '
+
+command=$1
+
+$command  '
 set mapred.job.tracker=local;
 DROP TABLE IF EXISTS one_row;
 CREATE TABLE one_row (number_of_rows INT);

--- a/scripts/make_one_row_complex.sh
+++ b/scripts/make_one_row_complex.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eux
 
+command=$1
+
 COLUMNS='
 `boolean` BOOLEAN,
 `tinyint` TINYINT,
@@ -18,7 +20,24 @@ COLUMNS='
 `decimal` DECIMAL(10, 1)
 '
 
-hive -e "
+SPARK_COLUMNS='
+`boolean` BOOLEAN,
+`tinyint` TINYINT,
+`smallint` SMALLINT,
+`int` INT,
+`bigint` BIGINT,
+`float` FLOAT,
+`double` DOUBLE,
+`string` STRING,
+`timestamp` TIMESTAMP,
+`binary` BINARY,
+`array` ARRAY<int>,
+`map` MAP<int, int>,
+`struct` STRUCT<a: int, b: int>,
+`decimal` DECIMAL(10, 1)
+'
+
+$command "
 set mapred.job.tracker=local;
 DROP TABLE IF EXISTS one_row_complex;
 DROP TABLE IF EXISTS one_row_complex_null;
@@ -56,6 +75,42 @@ INSERT OVERWRITE TABLE one_row_complex_null SELECT
     IF(false, map(1, 2, 3, 4), null),
     IF(false, named_struct('a', 1, 'b', 2), null),
     IF(false, create_union(0, 1, 'test_string'), null),
+    null
+FROM one_row;
+DROP TABLE IF EXISTS one_row_complex_spark;
+DROP TABLE IF EXISTS one_row_complex_spark_null;
+CREATE TABLE one_row_complex_spark ($SPARK_COLUMNS);
+CREATE TABLE one_row_complex_spark_null ($SPARK_COLUMNS);
+INSERT OVERWRITE TABLE one_row_complex_spark SELECT
+    true,
+    127,
+    32767,
+    2147483647,
+    9223372036854775807,
+    0.5,
+    0.25,
+    'a string',
+    0,
+    '123',
+    array(1, 2),
+    map(1, 2, 3, 4),
+    named_struct('a', 1, 'b', 2),
+    0.1
+FROM one_row;
+INSERT OVERWRITE TABLE one_row_complex_spark_null SELECT
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    IF(false, array(1, 2), null),
+    IF(false, map(1, 2, 3, 4), null),
+    IF(false, named_struct('a', 1, 'b', 2), null),
     null
 FROM one_row;
 "

--- a/scripts/make_test_database.sh
+++ b/scripts/make_test_database.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eux
-hive -e '
+
+  command=$1
+
+  $command '
 DROP DATABASE IF EXISTS pyhive_test_database CASCADE;
 CREATE DATABASE pyhive_test_database;
 CREATE TABLE pyhive_test_database.dummy_table (a INT);

--- a/scripts/make_test_tables.sh
+++ b/scripts/make_test_tables.sh
@@ -3,7 +3,9 @@
 # WARNING: drops and recreates tables called one_row, one_row_complex, and many_rows, plus a
 # database called pyhive_test_database.
 
-$(dirname $0)/make_one_row.sh
-$(dirname $0)/make_one_row_complex.sh
-$(dirname $0)/make_many_rows.sh
-$(dirname $0)/make_test_database.sh
+command="hive -e"
+
+$(dirname $0)/make_one_row.sh "$command"
+$(dirname $0)/make_one_row_complex.sh "$command"
+$(dirname $0)/make_many_rows.sh "$command"
+$(dirname $0)/make_test_database.sh "$command"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         # We use sasl3 as a drop-in replacement for sasl, since it resolves a couple
         # build issues that sasl has, especially on MacOS systems.
         'hive': ['sasl3>=0.2.11', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
-        'sqlalchemy': ['sqlalchemy>=1.3.0'],
+        'sqlalchemy': ['sqlalchemy>=1.3.0,<1.4.0'],
         'kerberos': ['requests_kerberos>=0.12.0'],
     },
     tests_require=[
@@ -72,6 +72,7 @@ setup(
             "hive.https = pyhive.sqlalchemy_hive:HiveHTTPSDialect",
             'presto = pyhive.sqlalchemy_presto:PrestoDialect',
             'trino = pyhive.sqlalchemy_trino:TrinoDialect',
+            'sparksql = pyhive.sqlalchemy_sparksql:SparkSqlDialect'
         ],
     }
 )


### PR DESCRIPTION
This pull request adds support for `sparksql` dialect which aims to be able to communicate with Spark Thrift Server - even though it is said to match hiveserver 1:1 in fact it does not. Implementation bases on Hive dialect but makes changes to it to make up for differences. Approach taken here was heavily based on existing attempts to add Spark Thrift Server to upstream PyHive (none of them accepted unfortunately):
https://github.com/dropbox/PyHive/pull/247
https://github.com/dropbox/PyHive/pull/187
Demand for this feature in upstream was shown in issues such as https://github.com/dropbox/PyHive/issues/150 but there was no follow up on maintainers side to include such change.
This PR beside actual sparksql dialect implementation contains set of unit tests to make sure it works and several improvements:
1. `SQLAlchemy` version is set to be `<1.4` as it contains breaking changes.
2. Tests setup scripts are improved a bit to allow for easier adjustment to particular development environment (i.e. hiveserver in docker)
3. Tests for sparksql dialect use different tables than those for Hive since Spark does not support uniontype.

I create this PR here as Datahub project uses this fork of pyhive and I have a need to fetch metadata of the tables via spark thrift server in Datahub. With this change it is possible to reuse Hive metadata connector to fetch data from Spark Thrift Server, given `schema` config option is set to `sparksql`.